### PR TITLE
Remove tac dependency from generate-config.sh

### DIFF
--- a/generate-config.sh
+++ b/generate-config.sh
@@ -166,7 +166,7 @@ nsc_table_to_json() {
 
     header=$(printf "${filtered}" | sed -n '2p' | awk '{ print $2 }')
     keys=$(printf "${filtered}" | sed -n '4p' | tr -d '[:blank:]' | sed 's/|$//;s/^|//')
-    values=$(printf "${filtered}" | sed -n '6,$p' | tac | sed '1d;s/|$//;s/^|//')
+    values=$(printf "${filtered}" | sed -n '6,$p' | sed 's/|$//;s/^|//')
 
     json=[]
 


### PR DESCRIPTION
- Removing `tac` as it is not always installed by default

The `tac | sed '1d'` previously was used to strip a table border from `nsc` output, but lines are now checked and skipped later in the function, so this is no longer required.